### PR TITLE
Full reduction

### DIFF
--- a/src/actions/hexes.js
+++ b/src/actions/hexes.js
@@ -1,8 +1,6 @@
 const uuidv4 = require('uuid/v4');
 
-/*
-* action types
- */
+/* action types */
 
 export const ADD_HEX_DETAIL = 'ADD_HEX_DETAIL'
 export const DELETE_HEX_DETAIL = 'DELETE_HEX_DETAIL'
@@ -10,9 +8,7 @@ export const ADD_HEX = 'ADD_HEX'
 export const UPDATE_HEX_TAGS = 'UPDATE_HEX_TAGS'
 export const UPDATE_HEX_COORDINATES = 'UPDATE_HEX_COORDINATES'
 
-/*
- * other constants
- */
+/* other constants */
 
 /* Example from official Redux docs https://redux.js.org/basics/actions#source-code
 export const VisibilityFilters = {
@@ -22,12 +18,10 @@ export const VisibilityFilters = {
 }
 */
 
-/*
- * action creators
- */
+/* action creators */
 
-export function addHexDetail(entryDetailText) {
-  return { type: ADD_HEX_DETAIL, payload: {'entryDetailText': entryDetailText, 'entryDetailId': uuidv4()} }
+export function addHexDetail(newEntryDetailText) {
+  return { type: ADD_HEX_DETAIL, payload: {'newEntryDetailText': newEntryDetailText, 'newEntryDetailId': uuidv4()} }
 }
 
 export function deleteHexDetail(entryDetailId) {
@@ -51,13 +45,20 @@ export function addHex(newCoordinates, newTerrain, newTerritory, replaceHex, rep
   } }
 }
 
-export function updateHexTags(coordinates, oldTerrain, oldTerritory, newTerrain, newTerritory) {
+export function updateHexTags(coordinates, newTerrain, newTerritory, oldTerrainTag, oldTerritoryTag) {
+  /*
+  :param coordinate: coordinates (tableEntry ID) of the hex we're updating tags on
+  :param newTerrain: new terrain tag ID of the hex
+  :param newTerritory: new territory tag ID of the hex
+  :param oldTerrainTag: full Tag object of the old terrain for hex
+  :param oldTerritoryTag: full Tag object of the old territory for hex
+  */
   return { type: UPDATE_HEX_TAGS, payload: {
     'coordinates': coordinates, 
-    'oldTerrain': oldTerrain,
-    'oldTerritory': oldTerritory,
     'newTerrain': newTerrain, 
-    'newTerritory': newTerritory
+    'newTerritory': newTerritory,
+    'oldTerrainTag': oldTerrainTag,
+    'oldTerritoryTag': oldTerritoryTag,
   } }
 }
 

--- a/src/actions/hexes.js
+++ b/src/actions/hexes.js
@@ -28,7 +28,7 @@ export function deleteHexDetail(entryDetailId) {
   return { type: DELETE_HEX_DETAIL, payload: {'entryDetailId': entryDetailId} }
 }
 
-export function addHex(newCoordinates, newTerrain, newTerritory, replaceHex, replaceTerritoryTag, replaceTerrainTag) {
+export function addHex(newCoordinates, newTerrain, newTerritory, replaceHex, replaceTerrainTag, replaceTerritoryTag) {
   /*
   :param newCoordinates: coordinates (tableEntry ID) of the new hex
   :param newTerrain: terrain tag ID of the new hex
@@ -40,8 +40,8 @@ export function addHex(newCoordinates, newTerrain, newTerritory, replaceHex, rep
     'newTerrain': newTerrain, 
     'newTerritory': newTerritory, 
     'replaceHex': replaceHex,
-    'replaceTerritoryTag': replaceTerritoryTag,
-    'replaceTerrainTag': replaceTerrainTag
+    'replaceTerrainTag': replaceTerrainTag,
+    'replaceTerritoryTag': replaceTerritoryTag
   } }
 }
 
@@ -62,6 +62,19 @@ export function updateHexTags(coordinates, newTerrain, newTerritory, oldTerrainT
   } }
 }
 
-export function updateHexCoordinates(oldCoordinates, newCoordinates) {
-  return { type: UPDATE_HEX_COORDINATES, payload: {'oldCoordinates': oldCoordinates, 'newCoordinates': newCoordinates} }
+export function updateHexCoordinates(newCoordinates, oldHex, replaceHex, replaceTerrainTag, replaceTerritoryTag) {
+  /*
+  :param newCoordinates: new coordinates (tableEntry ID) for the new hex
+  :param oldHex: full tableEntry object of the hexes previous state
+  :param replaceHex: existing hex tableEntry (if any) at the same coordinates that will be overwritten
+  :param replaceTerrainTag: existing full Tag object assinged to replaceHex.addTags[0]
+  :param replaceTerritoryTag: existing full Tag object assinged to replaceHex.addTags[1]
+  */
+  return { type: UPDATE_HEX_COORDINATES, payload: {
+    'newCoordinates': newCoordinates, 
+    'oldHex': oldHex,
+    'replaceHex': replaceHex,
+    'replaceTerrainTag': replaceTerrainTag,
+    'replaceTerritoryTag': replaceTerritoryTag,
+  } }
 }

--- a/src/actions/hexes.js
+++ b/src/actions/hexes.js
@@ -34,8 +34,21 @@ export function deleteHexDetail(entryDetailId) {
   return { type: DELETE_HEX_DETAIL, payload: {'entryDetailId': entryDetailId} }
 }
 
-export function addHex(coordinates, terrain, territory) {
-  return { type: ADD_HEX, payload: {'coordinates': coordinates, 'terrain': terrain, 'territory': territory} }
+export function addHex(newCoordinates, newTerrain, newTerritory, replaceHex, replaceTerritoryTag, replaceTerrainTag) {
+  /*
+  :param newCoordinates: coordinates (tableEntry ID) of the new hex
+  :param newTerrain: terrain tag ID of the new hex
+  :param newTerritory: territory tag ID of the new hex
+  :param replaceHex: existing hex tableEntry (if any) at the same coordinates that will be overwritten
+  */
+  return { type: ADD_HEX, payload: {
+    'newCoordinates': newCoordinates, 
+    'newTerrain': newTerrain, 
+    'newTerritory': newTerritory, 
+    'replaceHex': replaceHex,
+    'replaceTerritoryTag': replaceTerritoryTag,
+    'replaceTerrainTag': replaceTerrainTag
+  } }
 }
 
 export function updateHexTags(coordinates, oldTerrain, oldTerritory, newTerrain, newTerritory) {

--- a/src/components/tables.js
+++ b/src/components/tables.js
@@ -24,6 +24,15 @@ class DirectInputTableCell extends Component {
     onSubmit: () => console.log('default onSubmit')
   };
 
+  componentDidUpdate(prevProps) {
+    // this handles the case where, for example, the 'tag name' changed due to an exisitng hex being overwritten
+    // forces the cell to reset its default input value to the cell content
+    // otherwise this would only update on the next handleBlue() or handleChange()
+    if (this.props.content !== prevProps.content) {
+      this.setState({value: this.props.content})
+    }
+  }
+
   handleBlur() {
     this.setState({value: this.props.content, inputMode: false})
   }

--- a/src/components/tags.js
+++ b/src/components/tags.js
@@ -13,7 +13,7 @@ import { SingleLineAdder } from './forms'
 import './components.css';
 
 function getTerrainTags(tags) { 
-  return tags.allIds.filter(id => tags.byId[id].terrainHexes.length > 0 ).sort() 
+  return tags.allIds.filter(id => tags.byId[id].terrainHexes.length > 0 ).sort()
 };
 
 function getTerritoryTags(tags) {

--- a/src/containers/hexes.js
+++ b/src/containers/hexes.js
@@ -120,19 +120,19 @@ class HexesWorkspace extends Component {
   };
 
   handleSubmitTerrain(coordinates, value) {
-    const oldTerrain = this.props.tableEntries.byId[coordinates].addTags[0]
-    const oldTerritory = this.props.tableEntries.byId[coordinates].addTags[1]
     const newTerrain = value
     const newTerritory = this.props.tableEntries.byId[coordinates].addTags[1]
-    this.props.updateHexTags(coordinates, oldTerrain, oldTerritory, newTerrain, newTerritory)
+    const oldTerrainTag = this.props.tags.byId[this.props.tableEntries.byId[coordinates].addTags[0]]
+    const oldTerritoryTag = this.props.tags.byId[newTerritory]
+    this.props.updateHexTags(coordinates, newTerrain, newTerritory, oldTerrainTag, oldTerritoryTag)
   }
 
   handleSubmitTerritory(coordinates, value) {
-    const oldTerrain = this.props.tableEntries.byId[coordinates].addTags[0]
-    const oldTerritory = this.props.tableEntries.byId[coordinates].addTags[1]
     const newTerrain = this.props.tableEntries.byId[coordinates].addTags[0]
     const newTerritory = value
-    this.props.updateHexTags(coordinates, oldTerrain, oldTerritory, newTerrain, newTerritory)
+    const oldTerrainTag = this.props.tags.byId[newTerrain]
+    const oldTerritoryTag = this.props.tags.byId[this.props.tableEntries.byId[coordinates].addTags[1]]
+    this.props.updateHexTags(coordinates, newTerrain, newTerritory, oldTerrainTag, oldTerritoryTag)
   }
 
   handleSubmitCoordinates(coordinates, value) {

--- a/src/containers/hexes.js
+++ b/src/containers/hexes.js
@@ -87,7 +87,7 @@ class HexesWorkspace extends Component {
       const replaceHex = this.props.tableEntries.byId[newCoordinates]
       const replaceTerrainTag = replaceHex ? this.props.tags.byId[replaceHex.addTags[0]] : undefined
       const replaceTerritoryTag = replaceHex ? this.props.tags.byId[replaceHex.addTags[1]] : undefined
-      this.props.addHex(newCoordinates, newTerrain, newTerritory, replaceHex, replaceTerritoryTag, replaceTerrainTag)
+      this.props.addHex(newCoordinates, newTerrain, newTerritory, replaceHex, replaceTerrainTag, replaceTerritoryTag)
     }
   }
 
@@ -110,7 +110,7 @@ class HexesWorkspace extends Component {
         const replaceHex = this.props.tableEntries.byId[newCoordinates]
         const replaceTerrainTag = replaceHex ? this.props.tags.byId[replaceHex.addTags[0]] : undefined
         const replaceTerritoryTag = replaceHex ? this.props.tags.byId[replaceHex.addTags[1]] : undefined
-        this.props.addHex(newCoordinates, newTerrain, newTerritory, replaceHex, replaceTerritoryTag, replaceTerrainTag)
+        this.props.addHex(newCoordinates, newTerrain, newTerritory, replaceHex, replaceTerrainTag, replaceTerritoryTag)
       }
     }
   };
@@ -136,9 +136,12 @@ class HexesWorkspace extends Component {
   }
 
   handleSubmitCoordinates(coordinates, value) {
-    const oldCoordinates = coordinates
     const newCoordinates = value
-    this.props.updateHexCoordinates(oldCoordinates, newCoordinates)
+    const oldHex = this.props.tableEntries.byId[coordinates]
+    const replaceHex = this.props.tableEntries.byId[newCoordinates]
+    const replaceTerrainTag = replaceHex ? this.props.tags.byId[replaceHex.addTags[0]] : undefined
+    const replaceTerritoryTag = replaceHex ? this.props.tags.byId[replaceHex.addTags[1]] : undefined
+    this.props.updateHexCoordinates(newCoordinates, oldHex, replaceHex, replaceTerrainTag, replaceTerritoryTag)
   }
 
   createHexDataTable(tables, tableEntries, tags, onSubmitCoordinates, onSubmitTerrain, onSubmitTerritory) {

--- a/src/containers/hexes.js
+++ b/src/containers/hexes.js
@@ -96,7 +96,6 @@ class HexesWorkspace extends Component {
   };
 
   handleSubmitClickHexMapInputModal(value) {
-    console.log(`handleSubmitClickHexMapInputModal: ${value}`)
     this.setState({openHexMapInputModal: false})
     const lines = value.split('\n')
     const hexLineRegEx = /^[a-zA-Z0-9]+$|^[a-zA-Z0-9]+,[a-z]*$|^[a-zA-Z0-9]+,[a-z]*,[a-z]*$/

--- a/src/containers/hexes.js
+++ b/src/containers/hexes.js
@@ -81,8 +81,8 @@ class HexesWorkspace extends Component {
     const hexTagRegEx = /^[a-z]+$/ 
     if ( value.match(hexLineRegEx) ) {
       let [newCoordinates, newTerrain, newTerritory] = value.split(',')
-      newTerrain = newTerrain.match(hexTagRegEx) ? newTerrain : undefined
-      newTerritory = newTerritory.match(hexTagRegEx) ? newTerritory : undefined
+      newTerrain = newTerrain && newTerrain.match(hexTagRegEx) ? newTerrain : undefined
+      newTerritory = newTerritory && newTerritory.match(hexTagRegEx) ? newTerritory : undefined
       //are we overwriting an existing hex?
       const replaceHex = this.props.tableEntries.byId[newCoordinates]
       const replaceTerrainTag = replaceHex ? this.props.tags.byId[replaceHex.addTags[0]] : undefined
@@ -103,8 +103,8 @@ class HexesWorkspace extends Component {
     for (let i = 0; i < lines.length; i++) {
       if ( lines[i].match(hexLineRegEx) ) {
         let [newCoordinates, newTerrain, newTerritory] = lines[i].split(',')
-        newTerrain = newTerrain.match(hexTagRegEx) ? newTerrain : undefined
-        newTerritory = newTerritory.match(hexTagRegEx) ? newTerritory : undefined
+        newTerrain = newTerrain && newTerrain.match(hexTagRegEx) ? newTerrain : undefined
+        newTerritory = newTerritory && newTerritory.match(hexTagRegEx) ? newTerritory : undefined
         //are we overwriting an existing hex?
         const replaceHex = this.props.tableEntries.byId[newCoordinates]
         const replaceTerrainTag = replaceHex ? this.props.tags.byId[replaceHex.addTags[0]] : undefined

--- a/src/containers/hexes.js
+++ b/src/containers/hexes.js
@@ -80,10 +80,14 @@ class HexesWorkspace extends Component {
     const hexLineRegEx = /^[a-zA-Z0-9]+$|^[a-zA-Z0-9]+,[a-z]*$|^[a-zA-Z0-9]+,[a-z]*,[a-z]*$/
     const hexTagRegEx = /^[a-z]+$/ 
     if ( value.match(hexLineRegEx) ) {
-      let [coordinates, terrain, territory] = value.split(',')
-      terrain = ( terrain.match(hexTagRegEx) ? terrain : null )
-      territory = ( territory.match(hexTagRegEx) ? territory : null )
-      this.props.addHex(coordinates, terrain, territory)
+      let [newCoordinates, newTerrain, newTerritory] = value.split(',')
+      newTerrain = newTerrain.match(hexTagRegEx) ? newTerrain : undefined
+      newTerritory = newTerritory.match(hexTagRegEx) ? newTerritory : undefined
+      //are we overwriting an existing hex?
+      const replaceHex = this.props.tableEntries.byId[newCoordinates]
+      const replaceTerrainTag = replaceHex ? this.props.tags.byId[replaceHex.addTags[0]] : undefined
+      const replaceTerritoryTag = replaceHex ? this.props.tags.byId[replaceHex.addTags[1]] : undefined
+      this.props.addHex(newCoordinates, newTerrain, newTerritory, replaceHex, replaceTerritoryTag, replaceTerrainTag)
     }
   }
 

--- a/src/containers/hexes.js
+++ b/src/containers/hexes.js
@@ -103,10 +103,14 @@ class HexesWorkspace extends Component {
     const hexTagRegEx = /^[a-z]+$/ 
     for (let i = 0; i < lines.length; i++) {
       if ( lines[i].match(hexLineRegEx) ) {
-        let [coordinates, terrain, territory] = lines[i].split(',')
-        terrain = ( terrain.match(hexTagRegEx) ? terrain : null )
-        territory = ( territory.match(hexTagRegEx) ? territory : null )
-        this.props.addHex(coordinates, terrain, territory)
+        let [newCoordinates, newTerrain, newTerritory] = lines[i].split(',')
+        newTerrain = newTerrain.match(hexTagRegEx) ? newTerrain : undefined
+        newTerritory = newTerritory.match(hexTagRegEx) ? newTerritory : undefined
+        //are we overwriting an existing hex?
+        const replaceHex = this.props.tableEntries.byId[newCoordinates]
+        const replaceTerrainTag = replaceHex ? this.props.tags.byId[replaceHex.addTags[0]] : undefined
+        const replaceTerritoryTag = replaceHex ? this.props.tags.byId[replaceHex.addTags[1]] : undefined
+        this.props.addHex(newCoordinates, newTerrain, newTerritory, replaceHex, replaceTerritoryTag, replaceTerrainTag)
       }
     }
   };

--- a/src/containers/tags.js
+++ b/src/containers/tags.js
@@ -35,15 +35,16 @@ class TagsWorkspace extends Component {
     this.handleRemoveOtherTag = this.handleRemoveOtherTag.bind(this)
   };
 
-  handleSubmitOtherTag(tag) {
+  handleSubmitOtherTag(tagText) {
     const tagRegEx = /^[a-z]+$/
-    if ( tag.match(tagRegEx) ) {
-      this.props.addOtherTag(tag)
+    if ( tagText.match(tagRegEx) ) {
+      this.props.addOtherTag(tagText)
     }
   }
 
-  handleRemoveOtherTag(tag) {
-    this.props.deleteOtherTag(tag)
+  handleRemoveOtherTag(tagText) {
+    console.log(`tagText ${tagText}`)
+    this.props.deleteOtherTag(this.props.tags.byId[tagText])
   }
 
   render() {

--- a/src/reducers/entrydetails.js
+++ b/src/reducers/entrydetails.js
@@ -11,7 +11,7 @@ function byIdAddHexDetail(state, action) {
 function byIdDeleteHexDetail(state, action) {
   return ({
     ...state,
-    [action.payload.entryDetailId]: null
+    [action.payload.entryDetailId]: undefined
   })
 }
 

--- a/src/reducers/entrydetails.js
+++ b/src/reducers/entrydetails.js
@@ -4,7 +4,7 @@ import { ADD_HEX_DETAIL, DELETE_HEX_DETAIL } from '../actions/hexes'
 function byIdAddHexDetail(state, action) {
   return ({
     ...state,
-    [action.payload.entryDetailId]: {id: action.payload.entryDetailId, text: action.payload.entryDetailText}
+    [action.payload.newEntryDetailId]: {id: action.payload.newEntryDetailId, text: action.payload.newEntryDetailText}
   })
 }
 

--- a/src/reducers/entrydetails.js
+++ b/src/reducers/entrydetails.js
@@ -1,37 +1,55 @@
 import { combineReducers } from 'redux'
 import { ADD_HEX_DETAIL, DELETE_HEX_DETAIL } from '../actions/hexes'
 
+function byIdAddHexDetail(state, action) {
+  return ({
+    ...state,
+    [action.payload.entryDetailId]: {id: action.payload.entryDetailId, text: action.payload.entryDetailText}
+  })
+}
+
+function byIdDeleteHexDetail(state, action) {
+  return ({
+    ...state,
+    [action.payload.entryDetailId]: null
+  })
+}
+
 function byId(state=null, action) {
   console.log(state)
+  console.log(action)
   switch (action.type) {
     case ADD_HEX_DETAIL:
-      return ({
-        ...state,
-        [action.payload.entryDetailId]: {id: action.payload.entryDetailId, text: action.payload.entryDetailText}
-      })
+      return byIdAddHexDetail(state, action)
 
     case DELETE_HEX_DETAIL:
-      return ({
-        ...state,
-        [action.payload.entryDetailId]: null
-      })
+      return byIdDeleteHexDetail(state, action)
 
     default:
       return state
   }
 }
 
+function allIdsAddHexDetail(state, action) {
+  return ([
+    ...state,
+    action.payload.entryDetailId
+  ])
+}
+
+function allIdsDeleteHexDetail(state, action) {
+  return state.filter(item => item !== action.payload.entryDetailId)
+}
+
 function allIds(state=null, action) {
   console.log(state)
+  console.log(action)
   switch (action.type) {
     case ADD_HEX_DETAIL:
-      return ([
-        ...state,
-        action.payload.entryDetailId
-      ])
+      return allIdsAddHexDetail(state, action)
 
     case DELETE_HEX_DETAIL:
-      return state.filter(item => item !== action.payload.entryDetailId)
+      return allIdsDeleteHexDetail(state, action)
 
     default:
       return state

--- a/src/reducers/tableentries.js
+++ b/src/reducers/tableentries.js
@@ -16,7 +16,23 @@ function byIdUpdateHexTags(state, action) {
   return ({
     ...state,
     [action.payload.coordinates] : {
+      ...state[action.payload.coordinates],
       addTags: [action.payload.newTerrain, action.payload.newTerritory],
+    }
+  })
+}
+
+function byIdUpdateHexCoordinates(state, action) {
+  const newCoordinates = action.payload.newCoordinates
+  const oldHex = action.payload.oldHex
+  const oldHexCoordinates = (oldHex) ? oldHex.id : undefined
+  return ({
+    ...state,
+    [oldHexCoordinates]: undefined, //delete the hex at the old coordinates
+    [newCoordinates]: {
+      ...state[oldHexCoordinates], //copy info to the new coordinates
+      id: newCoordinates,
+      text: newCoordinates
     }
   })
 }
@@ -32,19 +48,23 @@ function byId(state=null, action) {
       return byIdUpdateHexTags(state, action)
 
     case UPDATE_HEX_COORDINATES:
-      return ({
-        ...state,
-        [action.payload.newCoordinates] : {
-          ...state[action.payload.oldCoordinates], //copy info to the new coordinates
-          id: action.payload.newCoordinates,
-          text: action.payload.newCoordinates
-        },
-        [action.payload.oldCoordinates] : null //delete the old coordinates
-      })
+      return byIdUpdateHexCoordinates(state, action)
 
     default:
       return state
   }
+}
+
+function allIdsAddHex(state, action) {
+  const newCoordinates = action.payload.newCoordinates
+  return [...state.filter(item => item != newCoordinates), newCoordinates]
+}
+
+function allIdsUpdateHexCoordinates(state, action) {
+  const newCoordinates = action.payload.newCoordinates
+  const oldHex = action.payload.oldHex
+  const oldHexCoordinates = (oldHex) ? oldHex.id : undefined
+  return [...state.filter(item => item != oldHexCoordinates && item != newCoordinates), newCoordinates]
 }
 
 function allIds(state=null, action) {
@@ -52,13 +72,10 @@ function allIds(state=null, action) {
   console.log(action)
   switch (action.type) {
     case ADD_HEX:
-      return [...state.filter(item => item != action.payload.newCoordinates), action.payload.newCoordinates]
+      return allIdsAddHex(state, action)
 
     case UPDATE_HEX_COORDINATES:
-      return ([
-        ...state.filter(item => (item != action.payload.oldCoordinates && item != action.payload.newCoordinates)),
-        action.payload.newCoordinates
-      ])
+      return allIdsUpdateHexCoordinates(state, action)
 
     default:
       return state

--- a/src/reducers/tableentries.js
+++ b/src/reducers/tableentries.js
@@ -7,10 +7,10 @@ function byId(state=null, action) {
     case ADD_HEX:
       return ({
         ...state,
-        [action.payload.coordinates] : {
-          id: action.payload.coordinates,
-          text: action.payload.coordinates,
-          addTags: [action.payload.terrain, action.payload.territory],
+        [action.payload.newCoordinates] : {
+          id: action.payload.newCoordinates,
+          text: action.payload.newCoordinates,
+          addTags: [action.payload.newTerrain, action.payload.newTerritory],
         }
       })
 
@@ -42,7 +42,7 @@ function allIds(state=null, action) {
   console.log(state)
   switch (action.type) {
     case ADD_HEX:
-      return [...state.filter(item => item != action.payload.coordinates), action.payload.coordinates]
+      return [...state.filter(item => item != action.payload.newCoordinates), action.payload.newCoordinates]
 
     case UPDATE_HEX_COORDINATES:
       return ([

--- a/src/reducers/tableentries.js
+++ b/src/reducers/tableentries.js
@@ -12,6 +12,15 @@ function byIdAddHex(state, action) {
   })
 }
 
+function byIdUpdateHexTags(state, action) {
+  return ({
+    ...state,
+    [action.payload.coordinates] : {
+      addTags: [action.payload.newTerrain, action.payload.newTerritory],
+    }
+  })
+}
+
 function byId(state=null, action) {
   console.log(state)
   console.log(action)
@@ -20,12 +29,7 @@ function byId(state=null, action) {
       return byIdAddHex(state, action)
 
     case UPDATE_HEX_TAGS:
-      return ({
-        ...state,
-        [action.payload.coordinates] : {
-          addTags: [action.payload.newTerrain, action.payload.newTerritory],
-        }
-      })
+      return byIdUpdateHexTags(state, action)
 
     case UPDATE_HEX_COORDINATES:
       return ({

--- a/src/reducers/tableentries.js
+++ b/src/reducers/tableentries.js
@@ -1,18 +1,23 @@
 import { combineReducers } from 'redux'
 import { ADD_HEX, UPDATE_HEX_TAGS, UPDATE_HEX_COORDINATES } from '../actions/hexes'
 
+function byIdAddHex(state, action) {
+  return ({
+    ...state,
+    [action.payload.newCoordinates] : {
+      id: action.payload.newCoordinates,
+      text: action.payload.newCoordinates,
+      addTags: [action.payload.newTerrain, action.payload.newTerritory],
+    }
+  })
+}
+
 function byId(state=null, action) {
   console.log(state)
+  console.log(action)
   switch (action.type) {
     case ADD_HEX:
-      return ({
-        ...state,
-        [action.payload.newCoordinates] : {
-          id: action.payload.newCoordinates,
-          text: action.payload.newCoordinates,
-          addTags: [action.payload.newTerrain, action.payload.newTerritory],
-        }
-      })
+      return byIdAddHex(state, action)
 
     case UPDATE_HEX_TAGS:
       return ({
@@ -40,6 +45,7 @@ function byId(state=null, action) {
 
 function allIds(state=null, action) {
   console.log(state)
+  console.log(action)
   switch (action.type) {
     case ADD_HEX:
       return [...state.filter(item => item != action.payload.newCoordinates), action.payload.newCoordinates]

--- a/src/reducers/tables.js
+++ b/src/reducers/tables.js
@@ -40,6 +40,22 @@ function byIdAddHex(state, action) {
   })
 }
 
+function byIdUpdateHexCoordinates(state, action) {
+  const newCoordinates = action.payload.newCoordinates
+  const oldHex = action.payload.oldHex
+  const oldHexCoordinates = (oldHex) ? oldHex.id : undefined
+  return ({
+    ...state,
+    'HEX': {
+      ...state['HEX'],
+      entries: [
+        ...state['HEX'].entries.filter(item => (item != oldHexCoordinates && item != newCoordinates)),
+        newCoordinates
+      ].sort() //always want hexes displayed in coordinate order
+    }
+  })
+}
+
 function byId(state=null, action) {
   console.log(state)
   console.log(action)
@@ -54,16 +70,7 @@ function byId(state=null, action) {
       return byIdAddHex(state, action)
 
     case UPDATE_HEX_COORDINATES:
-      return ({
-        ...state,
-        'HEX': {
-          ...state['HEX'],
-          entries: [
-            ...state['HEX'].entries.filter(item => (item != action.payload.oldCoordinates && item != action.payload.newCoordinates)),
-            action.payload.newCoordinates
-          ].sort()
-        }
-      })
+      return byIdUpdateHexCoordinates(state, action)
 
     default:
       return state

--- a/src/reducers/tables.js
+++ b/src/reducers/tables.js
@@ -8,7 +8,7 @@ function byIdAddHexDetail(state, action) {
       ...state['HEX'],
       globalEntryDetails: [
         ...state['HEX'].globalEntryDetails,
-        action.payload.entryDetailId
+        action.payload.newEntryDetailId
       ]
     }
   })

--- a/src/reducers/tables.js
+++ b/src/reducers/tables.js
@@ -34,8 +34,8 @@ function byId(state=null, action) {
           ...state['HEX'],
           entries: [
             //avoid duplicates
-            ...state['HEX'].entries.filter(item => item != action.payload.coordinates),
-            action.payload.coordinates
+            ...state['HEX'].entries.filter(item => item != action.payload.newCoordinates),
+            action.payload.newCoordinates
           ].sort() //always want hexes displayed in coordinate order
         }
       })

--- a/src/reducers/tables.js
+++ b/src/reducers/tables.js
@@ -1,44 +1,57 @@
 import { combineReducers } from 'redux'
 import { ADD_HEX_DETAIL, DELETE_HEX_DETAIL, ADD_HEX, UPDATE_HEX_COORDINATES } from '../actions/hexes'
 
+function byIdAddHexDetail(state, action) {
+  return ({
+    ...state,
+    'HEX': {
+      ...state['HEX'],
+      globalEntryDetails: [
+        ...state['HEX'].globalEntryDetails,
+        action.payload.entryDetailId
+      ]
+    }
+  })
+}
+
+function byIdDeleteHexDetail(state, action) {
+  return ({
+    ...state,
+    'HEX': {
+      ...state['HEX'],
+      globalEntryDetails: state['HEX'].globalEntryDetails.filter(item => item != action.payload.entryDetailId)
+    }
+  })
+}
+
+function byIdAddHex(state, action) {
+  //For the HEX table, we'll use the hex coordinates as the ID for each table entry, other tables will use uuid4
+  //should be safe to assume no collision between the two
+  return ({
+    ...state,
+    'HEX': {
+      ...state['HEX'],
+      entries: [
+        //avoid duplicates
+        ...state['HEX'].entries.filter(item => item != action.payload.newCoordinates),
+        action.payload.newCoordinates
+      ].sort() //always want hexes displayed in coordinate order
+    }
+  })
+}
+
 function byId(state=null, action) {
   console.log(state)
+  console.log(action)
   switch (action.type) {
     case ADD_HEX_DETAIL:
-      return ({
-        ...state,
-        'HEX': {
-          ...state['HEX'],
-          globalEntryDetails: [
-            ...state['HEX'].globalEntryDetails,
-            action.payload.entryDetailId
-          ]
-        }
-      })
+      return byIdAddHexDetail(state, action)
 
     case DELETE_HEX_DETAIL:
-      return ({
-        ...state,
-        'HEX': {
-          ...state['HEX'],
-          globalEntryDetails: state['HEX'].globalEntryDetails.filter(item => item != action.payload.entryDetailId)
-        }
-      })
+      return byIdDeleteHexDetail(state, action)
 
     case ADD_HEX:
-      //For the HEX table, we'll use the hex coordinates as the ID for each table entry, other tables will use uuid4
-      //should be safe to assume no collision between the two
-      return ({
-        ...state,
-        'HEX': {
-          ...state['HEX'],
-          entries: [
-            //avoid duplicates
-            ...state['HEX'].entries.filter(item => item != action.payload.newCoordinates),
-            action.payload.newCoordinates
-          ].sort() //always want hexes displayed in coordinate order
-        }
-      })
+      return byIdAddHex(state, action)
 
     case UPDATE_HEX_COORDINATES:
       return ({
@@ -59,6 +72,7 @@ function byId(state=null, action) {
 
 function allIds(state=null, action) {
   console.log(state)
+  console.log(action)
   switch (action.type) {
     
     default:

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -2,117 +2,52 @@ import { combineReducers } from 'redux'
 import { ADD_HEX, UPDATE_HEX_TAGS, UPDATE_HEX_COORDINATES } from '../actions/hexes'
 import { ADD_OTHER_TAG, DELETE_OTHER_TAG } from '../actions/tags'
 
-function newTerrainHex(state, coordinates, terrain) {
-  if ( state[terrain] ) {
-    return ({
-      ...state[terrain],
-      terrainHexes: [...state[terrain].terrainHexes, coordinates]
-    })
-  }
-  else {
-    return ({
-      id: terrain,
-      text: terrain,
-      terrainHexes: [coordinates],
-      territoryHexes: [],
-      otherTag: false
-    })
+function byId(state=null, action) {
+  console.log(state)
+  console.log(action)
+  switch (action.type) {
+    case ADD_HEX:
+      return byIdAddHex(state, action)
+
+    case UPDATE_HEX_TAGS:
+      return byIdUpdateHexTags(state, action)
+
+    case UPDATE_HEX_COORDINATES:
+      return byIdUpdateHexCoordinates(state, action)
+
+    case ADD_OTHER_TAG:
+      return byIdAddOtherTag(state, action)
+
+    case DELETE_OTHER_TAG:
+      return byIdDeleteOtherTag(state, action)
+
+    default:
+      return state
   }
 }
 
-function newTerritoryHex(state, coordinates, territory) {
-  if ( state[territory] ) {
-    return ({
-      ...state[territory],
-      territoryHexes: [...state[territory].territoryHexes, coordinates]
-    })
-  }
-  else {
-    return ({
-      id: territory,
-      text: territory,
-      terrainHexes: [],
-      territoryHexes: [coordinates],
-      otherTag: false
-    })
-  }
-}
+function allIds(state=null, action) {
+  console.log(state)
+  console.log(action)
+  let newState = []
+  switch (action.type) {
+    case ADD_HEX:
+      return allIdsAddHex(state, action)
 
-function newOtherTag(state, tag) {
-  if ( state[tag] ) {
-    return ({
-      ...state[tag],
-      otherTag: true
-    })
-  }
-  else {
-    return ({
-      id: tag,
-      text: tag,
-      terrainHexes: [],
-      territoryHexes: [],
-      otherTag: true
-    })
-  }
-}
+    case UPDATE_HEX_TAGS:
+      return allIdsUpdateHexTags(state, action)
 
-function removeTerrainHexFromTag(tag, coordinates) {
-  // Remove terrainHex reference from this tag, delete the tag if we can
-  const newTag = {
-    ...tag,
-    terrainHexes: [...tag.terrainHexes.filter(item => item != coordinates)]
-  }
-  // If the tag has no references to anything left, it can be effectively deleted. I.e. don't return it
-  if ( newTag.territoryHexes.length > 0 || newTag.terrainHexes.length > 0 || newTag.otherTag == true ) {
-    return newTag
-  }
-}
+    case UPDATE_HEX_COORDINATES:
+      return allIdsUpdateHexCoordinates(state, action)
 
-function removeTerritoryHexFromTag(tag, coordinates) {
-  // Remove territoryHex reference from this tag, delete the tag if we can
-  const newTag = {
-    ...tag,
-    territoryHexes: [...tag.territoryHexes.filter(item => item != coordinates)]
-  }
-  // If the tag has no references to anything left, it can be effectively deleted. I.e. don't return it
-  if ( newTag.territoryHexes.length > 0 || newTag.terrainHexes.length > 0 || newTag.otherTag == true ) {
-    return newTag
-  }
-}
+    case ADD_OTHER_TAG:
+      return allIdsAddOtherTag(state, action)
 
-function createOrUpdateTerrainTag(state, coordinates, terrain) {
-  if ( state[terrain] ) {
-    return ({
-      ...state[terrain],
-      terrainHexes: [...state[terrain].terrainHexes.filter(item => item != coordinates), coordinates]
-    })
-  }
-  else {
-    return ({
-      id: terrain,
-      text: terrain,
-      terrainHexes: [coordinates],
-      territoryHexes: [],
-      otherTag: false
-    })
-  }
-}
+    case DELETE_OTHER_TAG:
+      return allIdsDeleteOtherTag(state, action)
 
-function createOrUpdateTerritoryTag(state, coordinates, territory) {
-  if ( state[territory] ) {
-    return ({
-      ...state[territory],
-      territoryHexes: [...state[territory].territoryHexes.filter(item => item != coordinates), coordinates]
-    })
-  }
-  else {
-    return ({
-      id: territory,
-      text: territory,
-      terrainHexes: [],
-      territoryHexes: [coordinates],
-      otherTag: false
-    })
+    default:
+      return state
   }
 }
 
@@ -132,13 +67,17 @@ function byIdAddHex(state, action) {
     const replaceTerrain = action.payload.replaceHex.addTags[0]
     const replaceTerritory = action.payload.replaceHex.addTags[1]
     //have to do these separately to handle case where replaceTerrain and replaceTerritory have the same ID
-    newState = {
-      ...newState,
-      [replaceTerrain]: removeTerrainHexFromTag(newState[replaceTerrain], replaceCoordinates)
+    if (replaceTerrain) {
+      newState = {
+        ...newState,
+        [replaceTerrain]: removeTerrainHexFromTag(newState[replaceTerrain], replaceCoordinates)
+      }
     }
-    newState = {
-      ...newState,
-      [replaceTerritory]: removeTerritoryHexFromTag(newState[replaceTerritory], replaceCoordinates)
+    if (replaceTerritory) {
+      newState = {
+        ...newState,
+        [replaceTerritory]: removeTerritoryHexFromTag(newState[replaceTerritory], replaceCoordinates)
+      }
     }
   }
   //also have to do these separately in case newTerrain and newTerritory have the same value
@@ -207,13 +146,17 @@ function byIdUpdateHexCoordinates(state, action) {
     const replaceCoordinates = replaceHex.id
     const replaceTerrain = replaceHex.addTags[0]
     const replaceTerritory = replaceHex.addTags[1]
-    newState = {
-      ...newState,
-      [replaceTerrain]: removeTerrainHexFromTag(newState[replaceTerrain], replaceCoordinates)
+    if (replaceTerrain) {
+      newState = {
+        ...newState,
+        [replaceTerrain]: removeTerrainHexFromTag(newState[replaceTerrain], replaceCoordinates)
+      }
     }
-    newState = {
-      ...newState,
-      [replaceTerritory]: removeTerritoryHexFromTag(newState[replaceTerritory], replaceCoordinates)
+    if (replaceTerritory) {
+      newState = {
+        ...newState,
+        [replaceTerritory]: removeTerritoryHexFromTag(newState[replaceTerritory], replaceCoordinates)
+      }
     }
   }
   if (newState[terrain]) {
@@ -237,55 +180,18 @@ function byIdUpdateHexCoordinates(state, action) {
   return newState
 }
 
-function byId(state=null, action) {
-  console.log(state)
-  console.log(action)
-  switch (action.type) {
-    case ADD_HEX:
-      return byIdAddHex(state, action)
-
-    case UPDATE_HEX_TAGS:
-      return byIdUpdateHexTags(state, action)
-
-    case UPDATE_HEX_COORDINATES:
-      return byIdUpdateHexCoordinates(state, action)
-
-    case ADD_OTHER_TAG:
-      return ({
-        ...state,
-        [action.payload.tag]: newOtherTag(state, action.payload.tag)
-      })
-
-    case DELETE_OTHER_TAG:
-      return ({
-        ...state,
-        [action.payload.tag]: {
-          ...state[action.payload.tag],
-          otherTag: false
-        }
-      })
-
-    default:
-      return state
-  }
+function byIdAddOtherTag(state, action) {
+  return ({
+    ...state,
+    [action.payload.tag]: newOtherTag(state, action.payload.tag)
+  })
 }
 
-function wouldDeleteTag(tag, coordinates) {
-  /*
-  If we were to remove the coordinates from this tag's terrainHexes and territoryHexes, would the tag be deletable?
-  i.e. Would it have any references left?
-  */
-  const testTag = {
-    ...tag,
-    terrainHexes: [...tag.terrainHexes.filter(item => item != coordinates)],
-    territoryHexes: [...tag.territoryHexes.filter(item => item != coordinates)]
-  }
-  if ( testTag.territoryHexes.length > 0 || testTag.terrainHexes.length > 0 || testTag.otherTag == true ) {
-    return false
-  }
-  else {
-    return true
-  }
+function byIdDeleteOtherTag(state, action) {
+  return ({
+    ...state,
+    [action.payload.tag.id]: removeOtherFromTag(action.payload.tag)
+  })
 }
 
 function allIdsAddHex(state, action) {
@@ -364,31 +270,133 @@ function allIdsUpdateHexCoordinates(state, action) {
   return newState
 }
 
-function allIds(state=null, action) {
-  console.log(state)
-  console.log(action)
-  let newState = []
-  switch (action.type) {
-    case ADD_HEX:
-      return allIdsAddHex(state, action)
+function allIdsAddOtherTag(state, action) {
+  return ([
+    ...state.filter(item => item != action.payload.tag),
+    action.payload.tag
+  ])
+}
 
-    case UPDATE_HEX_TAGS:
-      return allIdsUpdateHexTags(state, action)
+function allIdsDeleteOtherTag(state, action) {
+  const tagId = action.payload.tag.id
+  if (wouldDeleteTag(action.payload.tag, null, true)) {
+    return [...state.filter(item => item != tagId)]
+  }
+  return state
+}
 
-    case UPDATE_HEX_COORDINATES:
-      return allIdsUpdateHexCoordinates(state, action)
+function newOtherTag(state, tag) {
+  if ( state[tag] ) {
+    return ({
+      ...state[tag],
+      otherTag: true
+    })
+  }
+  else {
+    return ({
+      id: tag,
+      text: tag,
+      terrainHexes: [],
+      territoryHexes: [],
+      otherTag: true
+    })
+  }
+}
 
-    case ADD_OTHER_TAG:
-      return ([
-        ...state.filter(item => item != action.payload.tag),
-        action.payload.tag
-      ])
+function removeTerrainHexFromTag(tag, coordinates) {
+  // Remove terrainHex reference from this tag, delete the tag if we can
+  const newTag = {
+    ...tag,
+    terrainHexes: [...tag.terrainHexes.filter(item => item != coordinates)]
+  }
+  // If the tag has no references to anything left, it can be effectively deleted. I.e. don't return it
+  if ( newTag.territoryHexes.length > 0 || newTag.terrainHexes.length > 0 || newTag.otherTag == true ) {
+    return newTag
+  }
+}
 
-    case DELETE_OTHER_TAG:
-      return state
+function removeTerritoryHexFromTag(tag, coordinates) {
+  // Remove territoryHex reference from this tag, delete the tag if we can
+  const newTag = {
+    ...tag,
+    territoryHexes: [...tag.territoryHexes.filter(item => item != coordinates)]
+  }
+  // If the tag has no references to anything left, it can be effectively deleted. I.e. don't return it
+  if ( newTag.territoryHexes.length > 0 || newTag.terrainHexes.length > 0 || newTag.otherTag == true ) {
+    return newTag
+  }
+}
 
-    default:
-      return state
+function removeOtherFromTag(tag) {
+  // Set this Tag as no longer an Other Tag, delete the tag if that leaves it with no references
+  console.log(`tag: ${tag}`)
+  const newTag = {
+    ...tag,
+    otherTag: false
+  }
+  // Only return the updated tag if it still has references
+  if ( newTag.territoryHexes.length > 0 || newTag.terrainHexes.length > 0 || newTag.otherTag == true ) {
+    return newTag
+  }
+}
+
+function createOrUpdateTerrainTag(state, coordinates, terrain) {
+  if ( state[terrain] ) {
+    return ({
+      ...state[terrain],
+      terrainHexes: [...state[terrain].terrainHexes.filter(item => item != coordinates), coordinates]
+    })
+  }
+  else {
+    return ({
+      id: terrain,
+      text: terrain,
+      terrainHexes: [coordinates],
+      territoryHexes: [],
+      otherTag: false
+    })
+  }
+}
+
+function createOrUpdateTerritoryTag(state, coordinates, territory) {
+  if ( state[territory] ) {
+    return ({
+      ...state[territory],
+      territoryHexes: [...state[territory].territoryHexes.filter(item => item != coordinates), coordinates]
+    })
+  }
+  else {
+    return ({
+      id: territory,
+      text: territory,
+      terrainHexes: [],
+      territoryHexes: [coordinates],
+      otherTag: false
+    })
+  }
+}
+
+function wouldDeleteTag(tag, coordinates, removeOther) {
+  /*
+  If we were to remove the coordinates from this tag's terrainHexes and territoryHexes, would the tag be deletable?
+  i.e. Would it have any references left?
+  */
+  let testTag = {
+    ...tag,
+    terrainHexes: [...tag.terrainHexes.filter(item => item != coordinates)],
+    territoryHexes: [...tag.territoryHexes.filter(item => item != coordinates)],
+  }
+  if (removeOther) {
+    testTag = {
+      ...testTag,
+      otherTag: false
+    }
+  }
+  if ( testTag.territoryHexes.length > 0 || testTag.terrainHexes.length > 0 || testTag.otherTag == true ) {
+    return false
+  }
+  else {
+    return true
   }
 }
 

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -56,15 +56,103 @@ function newOtherTag(state, tag) {
   }
 }
 
+function removeTerrainHexFromTag(tag, coordinates) {
+  // Remove terrainHex reference from this tag, delete the tag if we can
+  const newTag = {
+    ...tag,
+    terrainHexes: [...tag.terrainHexes.filter(item => item != coordinates)]
+  }
+  // If the tag has no references to anything left, it can be effectively deleted. I.e. don't return it
+  if ( newTag.territoryHexes.length > 0 || newTag.terrainHexes.length > 0 || newTag.otherTag == true ) {
+    return newTag
+  }
+}
+
+function removeTerritoryHexFromTag(tag, coordinates) {
+  // Remove territoryHex reference from this tag, delete the tag if we can
+  const newTag = {
+    ...tag,
+    territoryHexes: [...tag.territoryHexes.filter(item => item != coordinates)]
+  }
+  // If the tag has no references to anything left, it can be effectively deleted. I.e. don't return it
+  if ( newTag.territoryHexes.length > 0 || newTag.terrainHexes.length > 0 || newTag.otherTag == true ) {
+    return newTag
+  }
+}
+
+function createOrUpdateTerrainTag(state, coordinates, terrain) {
+  if ( state[terrain] ) {
+    return ({
+      ...state[terrain],
+      terrainHexes: [...state[terrain].terrainHexes.filter(item => item != coordinates), coordinates]
+    })
+  }
+  else {
+    return ({
+      id: terrain,
+      text: terrain,
+      terrainHexes: [coordinates],
+      territoryHexes: [],
+      otherTag: false
+    })
+  }
+}
+
+function createOrUpdateTerritoryTag(state, coordinates, territory) {
+  if ( state[territory] ) {
+    return ({
+      ...state[territory],
+      territoryHexes: [...state[territory].territoryHexes.filter(item => item != coordinates), coordinates]
+    })
+  }
+  else {
+    return ({
+      id: territory,
+      text: territory,
+      terrainHexes: [],
+      territoryHexes: [coordinates],
+      otherTag: false
+    })
+  }
+}
+
+function byIdAddHex(state, action) {
+  /*
+  1. Remove hex reference from the replaced hex's terrain tag
+  2. Remove hex reference from the replaced hex's territory tag
+  3. Create or update new territory tag with reference to new hex
+  4. Create or update new terrain tag with reference to new hex
+  */
+  const newCoordinates = action.payload.newCoordinates
+  const newTerrain = action.payload.newTerrain
+  const newTerritory = action.payload.newTerritory
+  if ( action.payload.replaceHex ) {
+    const replaceCoordinates = action.payload.replaceHex.id
+    const replaceTerrain = action.payload.replaceHex.addTags[0]
+    const replaceTerritory = action.payload.replaceHex.addTags[1]
+    return ({
+      ...state,
+      [replaceTerrain]: removeTerrainHexFromTag(state[replaceTerrain], replaceCoordinates),
+      [replaceTerritory]: removeTerritoryHexFromTag(state[replaceTerritory], replaceCoordinates),
+      [newTerrain]: createOrUpdateTerrainTag(state, newCoordinates, newTerrain),
+      [newTerritory]: createOrUpdateTerritoryTag(state, newCoordinates, newTerritory),
+    })
+  }
+  else {
+    return ({
+      ...state,
+      [newTerrain]: createOrUpdateTerrainTag(state, newCoordinates, newTerrain),
+      [newTerritory]: createOrUpdateTerritoryTag(state, newCoordinates, newTerritory),
+    })
+  }
+}
+
 function byId(state=null, action) {
   console.log(state)
+  let newState = {}
   switch (action.type) {
     case ADD_HEX:
-      return ({
-        ...state,
-        [action.payload.terrain]: newTerrainHex(state, action.payload.coordinates, action.payload.terrain),
-        [action.payload.territory]: newTerritoryHex(state, action.payload.coordinates, action.payload.territory)
-      })
+      return byIdAddHex(state, action)
 
     case UPDATE_HEX_TAGS:
       return ({
@@ -107,21 +195,75 @@ function byId(state=null, action) {
   }
 }
 
+function wouldDeleteTerrainTag(tag, terrainHex) {
+  // If we were to remove the terrainHex from this tag, would the tag be deletable?
+  // i.e. Would it have any references left?
+  console.log(tag)
+  console.log(terrainHex)
+  const testTag = {
+    ...tag,
+    terrainHexes: [...tag.terrainHexes.filter(item => item != terrainHex)]
+  }
+  console.log(testTag)
+  if ( testTag.territoryHexes.length > 0 || testTag.terrainHexes.length > 0 || testTag.otherTag == true ) {
+    console.log('false')
+    return false
+  }
+  else {
+    console.log('true')
+    return true
+  }
+}
+
+function wouldDeleteTerritoryTag(tag, territoryHex) {
+  // If we were to remove the territoryHex from this tag, would the tag be deletable?
+  // i.e. Would it have any references left?
+  const testTag = {
+    ...tag,
+    territoryHexes: [...tag.territoryHexes.filter(item => item != territoryHex)]
+  }
+  if ( testTag.territoryHexes.length > 0 || testTag.terrainHexes.length > 0 || testTag.otherTag == true ) {
+    return false
+  }
+  else {
+    return true
+  }
+}
+
+function allIdsAddHex(state, action) {
+  /*
+  1. If removing the replaceHex coordinate from the replaceTerrain tag would leave it with no references, remove it from the list
+  2. If removing the replaceHex coordinate from the replaceTerritory tag would leave it with no references, remove it from the list
+  3. Add the new terrain and territory tags to the list
+  */
+  const newCoordinates = action.payload.newCoordinates
+  const newTerrain = action.payload.newTerrain
+  const newTerritory = action.payload.newTerritory
+  const replaceTerrainTag = action.payload.replaceTerrainTag
+  const replaceTerritoryTag = action.payload.replaceTerritoryTag
+  let newState = [...state]
+  if (replaceTerrainTag && wouldDeleteTerrainTag(replaceTerrainTag, newCoordinates)) {
+    newState = [...newState.filter(item => item != replaceTerrainTag.id)]
+  }
+  if (replaceTerritoryTag && wouldDeleteTerritoryTag(replaceTerritoryTag, newCoordinates)) {
+    newState = [...newState.filter(item => item != replaceTerritoryTag.id)]
+  }
+  if ( newTerrain ) {
+    newState = [...newState.filter(item => item != newTerrain), newTerrain]
+  }
+  if ( newTerritory ) {
+    newState = [...newState.filter(item => item != newTerritory), newTerritory]
+  }
+  return newState
+}
+
 function allIds(state=null, action) {
   console.log(state)
+  console.log(action)
   let newState = []
   switch (action.type) {
     case ADD_HEX:
-      // We want to avoid duplicates in the list, so doing some filtering herez
-      // We also want to prevent null, undefined, etc. ending up in this
-      newState = [...state]
-      if ( action.payload.terrain ) {
-        newState = [...newState.filter(item => item != action.payload.terrain), action.payload.terrain]
-      }
-      if ( action.payload.territory ) {
-        newState = [...newState.filter(item => item != action.payload.territory), action.payload.territory]
-      }
-      return newState
+      return allIdsAddHex(state, action)
 
     case UPDATE_HEX_TAGS:
       // We want to avoid duplicates in the list, so doing some filtering herez

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -126,25 +126,31 @@ function byIdAddHex(state, action) {
   const newCoordinates = action.payload.newCoordinates
   const newTerrain = action.payload.newTerrain
   const newTerritory = action.payload.newTerritory
+  let newState = {...state}
   if ( action.payload.replaceHex ) {
     const replaceCoordinates = action.payload.replaceHex.id
     const replaceTerrain = action.payload.replaceHex.addTags[0]
     const replaceTerritory = action.payload.replaceHex.addTags[1]
-    return ({
-      ...state,
-      [replaceTerrain]: removeTerrainHexFromTag(state[replaceTerrain], replaceCoordinates),
-      [replaceTerritory]: removeTerritoryHexFromTag(state[replaceTerritory], replaceCoordinates),
-      [newTerrain]: createOrUpdateTerrainTag(state, newCoordinates, newTerrain),
-      [newTerritory]: createOrUpdateTerritoryTag(state, newCoordinates, newTerritory),
-    })
+    //have to do these separately to handle case where replaceTerrain and replaceTerritory have the same ID
+    newState = {
+      ...newState,
+      [replaceTerrain]: removeTerrainHexFromTag(newState[replaceTerrain], replaceCoordinates),
+    }
+    newState = {
+      ...newState,
+      [replaceTerritory]: removeTerritoryHexFromTag(newState[replaceTerritory], replaceCoordinates),
+    }
   }
-  else {
-    return ({
-      ...state,
-      [newTerrain]: createOrUpdateTerrainTag(state, newCoordinates, newTerrain),
-      [newTerritory]: createOrUpdateTerritoryTag(state, newCoordinates, newTerritory),
-    })
+  //also have to do these separately in case newTerrain and newTerritory have the same value
+  newState = {
+    ...newState,
+    [newTerrain]: createOrUpdateTerrainTag(newState, newCoordinates, newTerrain),
   }
+  newState = {
+    ...newState,
+    [newTerritory]: createOrUpdateTerritoryTag(newState, newCoordinates, newTerritory),
+  }
+  return newState
 }
 
 function byIdUpdateHexTags(state, action) {
@@ -161,13 +167,26 @@ function byIdUpdateHexTags(state, action) {
   const oldTerritoryTag = action.payload.oldTerritoryTag
   const oldTerrainTagId = (oldTerrainTag) ? oldTerrainTag.id : undefined;
   const oldTerritoryTagId = (oldTerritoryTag) ? oldTerritoryTag.id : undefined;
-  return ({
-    ...state,
+  let newState = {...state}
+  // Have to do all of these separately to handle cases where territory and terrain have the same ID,
+  // otherwise terrainHexes and territoryHexes arrays won't be correct
+  newState = {
+    ...newState,
     [oldTerrainTagId]: (oldTerrainTagId) ? removeTerrainHexFromTag(oldTerrainTag, coordinates) : undefined,
+  }
+  newState = {
+    ...newState,
     [oldTerritoryTagId]: (oldTerritoryTagId) ? removeTerritoryHexFromTag(oldTerritoryTag, coordinates) : undefined,
-    [newTerrain]: createOrUpdateTerrainTag(state, coordinates, newTerrain),
-    [newTerritory] : createOrUpdateTerritoryTag(state, coordinates, newTerritory)
-  })
+  }
+  newState = {
+    ...newState,
+    [newTerrain]: createOrUpdateTerrainTag(newState, coordinates, newTerrain),
+  }
+  newState = {
+    ...newState,
+    [newTerritory] : createOrUpdateTerritoryTag(newState, coordinates, newTerritory)
+  }
+  return newState
 }
 
 function byId(state=null, action) {

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -149,7 +149,6 @@ function byIdAddHex(state, action) {
 
 function byId(state=null, action) {
   console.log(state)
-  let newState = {}
   switch (action.type) {
     case ADD_HEX:
       return byIdAddHex(state, action)

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -149,6 +149,7 @@ function byIdAddHex(state, action) {
 
 function byId(state=null, action) {
   console.log(state)
+  console.log(action)
   switch (action.type) {
     case ADD_HEX:
       return byIdAddHex(state, action)

--- a/src/reducers/tags.js
+++ b/src/reducers/tags.js
@@ -270,27 +270,15 @@ function byId(state=null, action) {
   }
 }
 
-function wouldDeleteTerrainTag(tag, terrainHex) {
-  // If we were to remove the terrainHex from this tag, would the tag be deletable?
-  // i.e. Would it have any references left?
+function wouldDeleteTag(tag, coordinates) {
+  /*
+  If we were to remove the coordinates from this tag's terrainHexes and territoryHexes, would the tag be deletable?
+  i.e. Would it have any references left?
+  */
   const testTag = {
     ...tag,
-    terrainHexes: [...tag.terrainHexes.filter(item => item != terrainHex)]
-  }
-  if ( testTag.territoryHexes.length > 0 || testTag.terrainHexes.length > 0 || testTag.otherTag == true ) {
-    return false
-  }
-  else {
-    return true
-  }
-}
-
-function wouldDeleteTerritoryTag(tag, territoryHex) {
-  // If we were to remove the territoryHex from this tag, would the tag be deletable?
-  // i.e. Would it have any references left?
-  const testTag = {
-    ...tag,
-    territoryHexes: [...tag.territoryHexes.filter(item => item != territoryHex)]
+    terrainHexes: [...tag.terrainHexes.filter(item => item != coordinates)],
+    territoryHexes: [...tag.territoryHexes.filter(item => item != coordinates)]
   }
   if ( testTag.territoryHexes.length > 0 || testTag.terrainHexes.length > 0 || testTag.otherTag == true ) {
     return false
@@ -312,10 +300,10 @@ function allIdsAddHex(state, action) {
   const replaceTerrainTag = action.payload.replaceTerrainTag
   const replaceTerritoryTag = action.payload.replaceTerritoryTag
   let newState = [...state]
-  if (replaceTerrainTag && wouldDeleteTerrainTag(replaceTerrainTag, newCoordinates)) {
+  if (replaceTerrainTag && wouldDeleteTag(replaceTerrainTag, newCoordinates)) {
     newState = [...newState.filter(item => item != replaceTerrainTag.id)]
   }
-  if (replaceTerritoryTag && wouldDeleteTerritoryTag(replaceTerritoryTag, newCoordinates)) {
+  if (replaceTerritoryTag && wouldDeleteTag(replaceTerritoryTag, newCoordinates)) {
     newState = [...newState.filter(item => item != replaceTerritoryTag.id)]
   }
   if ( newTerrain ) {
@@ -341,10 +329,10 @@ function allIdsUpdateHexTags(state, action) {
   const oldTerrainTagId = (oldTerrainTag) ? oldTerrainTag.id : undefined;
   const oldTerritoryTagId = (oldTerritoryTag) ? oldTerritoryTag.id : undefined;
   let newState = [...state]
-  if (oldTerrainTag && wouldDeleteTerrainTag(oldTerrainTag, coordinates)) {
+  if (oldTerrainTag && wouldDeleteTag(oldTerrainTag, coordinates)) {
     newState = [...newState.filter(item => item != oldTerrainTagId)]
   }
-  if (oldTerritoryTag && wouldDeleteTerritoryTag(oldTerritoryTag, coordinates)) {
+  if (oldTerritoryTag && wouldDeleteTag(oldTerritoryTag, coordinates)) {
     newState = [...newState.filter(item => item != oldTerritoryTagId)]
   }
   // Do these separately to avoid duplicates in cases where newTerrain and newTerritory have the same text
@@ -367,10 +355,10 @@ function allIdsUpdateHexCoordinates(state, action) {
   const replaceTerrainTag = action.payload.replaceTerrainTag
   const replaceTerritoryTag = action.payload.replaceTerritoryTag
   let newState = [...state]
-  if (replaceTerrainTag && wouldDeleteTerrainTag(replaceTerrainTag, newCoordinates)) {
+  if (replaceTerrainTag && wouldDeleteTag(replaceTerrainTag, newCoordinates)) {
     newState = [...newState.filter(item => item != replaceTerrainTag.id)]
   }
-  if (replaceTerritoryTag && wouldDeleteTerritoryTag(replaceTerritoryTag, newCoordinates)) {
+  if (replaceTerritoryTag && wouldDeleteTag(replaceTerritoryTag, newCoordinates)) {
     newState = [...newState.filter(item => item != replaceTerritoryTag.id)]
   }
   return newState


### PR DESCRIPTION
For hexes and tags, should be complete making the actions/reducers "full". I.e. Actually cleanup/remove/delete data when, for example, a hex is overwritten. Actually go through and remove hex references from all of the related tags, potentially delete the tags if they no longer have references anywhere, etc.

Basically leave no garbage in the entities store that we have to filter out when querying. Makes the reducers more complicated, but makes views more straightforward.